### PR TITLE
Implement access control for collections and handle protected content

### DIFF
--- a/src/app/(app)/(library)/library/[productId]/ProductView.tsx
+++ b/src/app/(app)/(library)/library/[productId]/ProductView.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Product } from "@/payload-types";
 import { useTRPC } from "@/trpc/client";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
@@ -13,7 +14,12 @@ const ProductView = ({ productId }: Props) => {
   const { data: order } = useSuspenseQuery(
     trpc.library.getOne.queryOptions({ productId })
   );
-  const product = order?.docs[0];
+  const { product } =
+    typeof order?.docs[0] === "string"
+      ? ({} as Product & { product: Product })
+      : (order?.docs[0] as { product: Product });
+
+  console.log(product);
 
   return (
     <div>
@@ -27,9 +33,13 @@ const ProductView = ({ productId }: Props) => {
           </div>
         </div>
         <div className="lg:col-span-5">
-          <p className="font-medium italic text-muted-foreground">
-            No Special Content
-          </p>
+          {product.content ? (
+            <p className="font-medium">{product.content}</p>
+          ) : (
+            <p className="font-medium italic text-muted-foreground">
+              No Special Content
+            </p>
+          )}
         </div>
       </section>
     </div>

--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -1,9 +1,18 @@
+import { isSuperAdmin } from "@/lib/access";
+
 import type { CollectionConfig } from "payload";
 
 export const Categories: CollectionConfig = {
   slug: "categories",
+  access: {
+    read: () => true,
+    create: ({ req }) => isSuperAdmin(req.user),
+    update: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user),
+  },
   admin: {
     useAsTitle: "name",
+    hidden: ({ user }) => !isSuperAdmin(user),
   },
   fields: [
     {

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -1,16 +1,22 @@
-import type { CollectionConfig } from 'payload'
+import { isSuperAdmin } from "@/lib/access";
+
+import type { CollectionConfig } from "payload";
 
 export const Media: CollectionConfig = {
-  slug: 'media',
+  slug: "media",
   access: {
     read: () => true,
+    delete: ({ req }) => isSuperAdmin(req.user),
+  },
+  admin: {
+    hidden: ({ user }) => !isSuperAdmin(user),
   },
   fields: [
     {
-      name: 'alt',
-      type: 'text',
+      name: "alt",
+      type: "text",
       required: true,
     },
   ],
   upload: true,
-}
+};

--- a/src/collections/Orders.ts
+++ b/src/collections/Orders.ts
@@ -1,7 +1,15 @@
+import { isSuperAdmin } from "@/lib/access";
+
 import type { CollectionConfig } from "payload";
 
 export const Orders: CollectionConfig = {
   slug: "orders",
+  access: {
+    read: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user),
+    update: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user),
+  },
   admin: {
     useAsTitle: "name",
   },
@@ -29,6 +37,10 @@ export const Orders: CollectionConfig = {
       name: "stripeCheckoutSessionId",
       type: "text",
       required: true,
+      admin: {
+        description:
+          "The Stripe Checkout Session ID associated with this order.",
+      },
     },
   ],
 };

--- a/src/collections/Products.ts
+++ b/src/collections/Products.ts
@@ -1,7 +1,19 @@
+import { isSuperAdmin } from "@/lib/access";
+import { Tenant } from "@/payload-types";
+
 import type { CollectionConfig } from "payload";
 
 export const Products: CollectionConfig = {
   slug: "products",
+  access: {
+    read: () => true,
+    create: ({ req }) => {
+      if (isSuperAdmin(req.user)) return true;
+
+      const tenant = req.user?.tenants?.[0]?.tenant as Tenant;
+      return Boolean(tenant?.stripeDetailsSubmitted);
+    },
+  },
   admin: {
     useAsTitle: "name",
   },
@@ -13,6 +25,7 @@ export const Products: CollectionConfig = {
     },
     {
       name: "description",
+      // TODO: switch to richText
       type: "text",
     },
     {
@@ -60,6 +73,15 @@ export const Products: CollectionConfig = {
       ],
       defaultValue: "no-refunds",
       required: true,
+    },
+    {
+      name: "content",
+      // TODO: switch to richText
+      type: "textarea",
+      admin: {
+        description:
+          "Protected content, only accessible after purchase. Add product documentation, downloadable files, getting started guides, and bonus materials here. Support Markdown formatting.",
+      },
     },
   ],
 };

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -1,7 +1,15 @@
+import { isSuperAdmin } from "@/lib/access";
+
 import type { CollectionConfig } from "payload";
 
 export const Reviews: CollectionConfig = {
   slug: "reviews",
+  access: {
+    read: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user),
+    update: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user),
+  },
   admin: {
     useAsTitle: "description",
   },

--- a/src/collections/Tags.ts
+++ b/src/collections/Tags.ts
@@ -1,9 +1,18 @@
+import { isSuperAdmin } from "@/lib/access";
+
 import type { CollectionConfig } from "payload";
 
 export const Tags: CollectionConfig = {
   slug: "tags",
+  access: {
+    read: () => true,
+    create: ({ req }) => isSuperAdmin(req.user),
+    update: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user),
+  },
   admin: {
     useAsTitle: "name",
+    hidden: ({ user }) => !isSuperAdmin(user),
   },
   fields: [
     {

--- a/src/collections/Tenants.ts
+++ b/src/collections/Tenants.ts
@@ -1,7 +1,13 @@
+import { isSuperAdmin } from "@/lib/access";
+
 import type { CollectionConfig } from "payload";
 
 export const Tenants: CollectionConfig = {
   slug: "tenants",
+  access: {
+    create: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user),
+  },
   admin: {
     useAsTitle: "slug",
   },
@@ -22,6 +28,9 @@ export const Tenants: CollectionConfig = {
       admin: {
         description: "The unique domain for the store (e.g. hamas.gumroad.com)",
       },
+      access: {
+        update: ({ req }) => isSuperAdmin(req.user),
+      },
     },
     {
       name: "image",
@@ -38,12 +47,11 @@ export const Tenants: CollectionConfig = {
       required: true,
       label: "Stripe Account ID",
       admin: {
-        readOnly: true,
         description:
           "The Stripe Account ID for the store (e.g. acct_1N2bCdEfGhIjKlMn)",
       },
       access: {
-        read: ({ req }) => req.user?.roles?.includes?.("super-admin") === true,
+        update: ({ req }) => isSuperAdmin(req.user),
       },
     },
     {
@@ -52,12 +60,11 @@ export const Tenants: CollectionConfig = {
       required: true,
       label: "Stripe Details Submitted",
       admin: {
-        readOnly: true,
         description:
           "You can't create products or accept payments until stripe details are submitted",
       },
       access: {
-        read: ({ req }) => req.user?.roles?.includes?.("super-admin") === true,
+        update: ({ req }) => isSuperAdmin(req.user),
       },
     },
   ],

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -1,0 +1,9 @@
+import { ClientUser } from "payload";
+
+import type { User } from "@/payload-types";
+
+export const isSuperAdmin = (
+  user: ClientUser | User | null | undefined
+): boolean => {
+  return Boolean(user?.roles?.includes("super-admin"));
+};

--- a/src/modules/checkout/server/procedures.ts
+++ b/src/modules/checkout/server/procedures.ts
@@ -110,6 +110,9 @@ export const checkoutRouter = createTRPCRouter({
         where: {
           id: { in: input.productIds },
         },
+        select: {
+          content: false, // Exclude protected content
+        },
         depth: 2,
       });
 

--- a/src/modules/products/server/procedures.ts
+++ b/src/modules/products/server/procedures.ts
@@ -1,11 +1,11 @@
-import { headers as getHeaders } from 'next/headers';
-import { z } from 'zod';
+import { headers as getHeaders } from "next/headers";
+import { z } from "zod";
 
-import { DEFAULT_PRODUCTS_LIMIT } from '@/constants';
-import { Tenant } from '@/payload-types';
-import { baseProcedure, createTRPCRouter } from '@/trpc/init';
+import { DEFAULT_PRODUCTS_LIMIT } from "@/constants";
+import { Tenant } from "@/payload-types";
+import { baseProcedure, createTRPCRouter } from "@/trpc/init";
 
-import { sortTypes } from '../searchParams';
+import { sortTypes } from "../searchParams";
 
 import type { Where } from "payload";
 export const productsRouter = createTRPCRouter({
@@ -16,6 +16,9 @@ export const productsRouter = createTRPCRouter({
         collection: "products",
         id: input.productId,
         depth: 2,
+        select: {
+          content: false, // Exclude protected content
+        },
       });
 
       const reviews = await ctx.payload.find({
@@ -141,6 +144,9 @@ export const productsRouter = createTRPCRouter({
         sort,
         page: input.cursor,
         limit: input.limit,
+        select: {
+          content: false, // Exclude protected content
+        },
       });
 
       const productIds = data.docs.map((product) => product.id);

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -244,6 +244,10 @@ export interface Product {
   category?: (string | null) | Category;
   tags?: (string | Tag)[] | null;
   refundPolicy: 'no-refunds' | '30-days' | '60-days';
+  /**
+   * Protected content, only accessible after purchase. Add product documentation, downloadable files, getting started guides, and bonus materials here. Support Markdown formatting.
+   */
+  content?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -267,6 +271,9 @@ export interface Order {
   name: string;
   user: string | User;
   product: string | Product;
+  /**
+   * The Stripe Checkout Session ID associated with this order.
+   */
   stripeCheckoutSessionId: string;
   updatedAt: string;
   createdAt: string;
@@ -439,6 +446,7 @@ export interface ProductsSelect<T extends boolean = true> {
   category?: T;
   tags?: T;
   refundPolicy?: T;
+  content?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
Introduce access control for various collections, allowing only super admins to create, update, and delete items. Add handling for protected content in products, ensuring it is only accessible after purchase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Products can now include protected content, shown on the product page after purchase (supports Markdown).

* Access Control
  * Tightened permissions across Users, Tenants, Orders, Reviews, Categories, Tags, and Media: create/update/delete limited to super admins; some admin sections are hidden for non‑super‑admins.
  * Users can still update their own profile.

* Privacy
  * Protected product content is excluded from public product listings and checkout responses to prevent unintended exposure.

* UI
  * Product pages now display available protected content instead of a static placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->